### PR TITLE
removed default, added validation

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -2,5 +2,5 @@ class Booking < ApplicationRecord
   belongs_to :user
   belongs_to :dinosaur
 
-  validates :user, :dinosaur, presence: true
+  validates :user, :dinosaur, :confirmation_status, presence: true
 end

--- a/db/migrate/20230302100814_change_confirmation_default_on_booking.rb
+++ b/db/migrate/20230302100814_change_confirmation_default_on_booking.rb
@@ -1,0 +1,5 @@
+class ChangeConfirmationDefaultOnBooking < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :bookings, :confirmation_status, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_28_094229) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_02_100814) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -43,7 +43,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_28_094229) do
   end
 
   create_table "bookings", force: :cascade do |t|
-    t.boolean "confirmation_status", default: false
+    t.boolean "confirmation_status"
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
- Removed confirmation_status default value for Bookings table, b/c Heroku wasn't picking it up-
- Added validation to Booking model to include presence "true" for confirmation_status